### PR TITLE
Fixed some points

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -25,7 +25,7 @@ type BackendContainer struct {
 // Discovery backend discovery
 type Discovery struct {
 	cli         *client.Client
-	mu          *sync.RWMutex
+	mu          *sync.Mutex
 	backends    []BackendContainer
 	filter      filters.Args
 	privatePort uint16
@@ -41,7 +41,7 @@ func NewDiscovery(label string, privatePort uint16) (*Discovery, error) {
 	filter.Add("label", label)
 	return &Discovery{
 		cli:         cli,
-		mu:          new(sync.RWMutex),
+		mu:          new(sync.Mutex),
 		filter:      filter,
 		privatePort: privatePort,
 	}, nil

--- a/motarei.go
+++ b/motarei.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"time"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/kazeburo/motarei/discovery"
@@ -16,12 +17,12 @@ import (
 var Version string
 
 type cmdOpts struct {
-	Listen              string `short:"l" long:"listen" default:"0.0.0.0" description:"address to bind"`
-	Port                string `short:"p" long:"port" description:"Port number to bind" required:"true"`
-	DockerLabel         string `long:"docker-label" description:"label to filter container. eg app=nginx" required:"true"`
-	DockerPrivatePort   uint16 `long:"docker-private-port" description:"Private port of container to use" required:"true"`
-	ProxyConnectTimeout uint16 `long:"proxy-connect-timeout" default:"60" description:"timeout of connection to upstream"`
-	Version             bool   `short:"v" long:"version" description:"Show version"`
+	Listen              string        `short:"l" long:"listen" default:"0.0.0.0" description:"address to bind"`
+	Port                string        `short:"p" long:"port" description:"Port number to bind" required:"true"`
+	DockerLabel         string        `long:"docker-label" description:"label to filter container. eg app=nginx" required:"true"`
+	DockerPrivatePort   uint16        `long:"docker-private-port" description:"Private port of container to use" required:"true"`
+	ProxyConnectTimeout time.Duration `long:"proxy-connect-timeout" default:"60s" description:"timeout of connection to upstream"`
+	Version             bool          `short:"v" long:"version" description:"Show version"`
 }
 
 func main() {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -85,9 +85,13 @@ func (p *Proxy) handleConn(ctx context.Context, c net.Conn) error {
 
 	var wg errgroup.Group
 
+	defer func() {
+		c.Close()
+		s.Close()
+	}()
+
 	// client => upstream
 	wg.Go(func() error {
-		defer s.Close()
 		_, err := io.Copy(s, c)
 		if err != nil {
 			return fmt.Errorf("Copy from client: %v", err)
@@ -97,7 +101,6 @@ func (p *Proxy) handleConn(ctx context.Context, c net.Conn) error {
 
 	// upstream => client
 	wg.Go(func() error {
-		defer c.Close()
 		_, err := io.Copy(c, s)
 		if err != nil {
 			return fmt.Errorf("Copy from upstream: %v", err)


### PR DESCRIPTION
## Motivation

- I wanted to make the timeout option a bit more easily
- I wanted you to use errgroup

## Fixed points

- `proxy-connect-timeout` option (we can easily to set seconds as `60s` or minutes as `1m`)
- return error backends if empty
- use [errgroup](https://godoc.org/golang.org/x/sync/errgroup)