### PR TITLE
replace logger to go.uber.org/zap

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -82,6 +82,37 @@
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
+  name = "go.uber.org/atomic"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:60bf2a5e347af463c42ed31a493d817f8a72f102543060ed992754e689805d1a"
+  name = "go.uber.org/multierr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:c52caf7bd44f92e54627a31b85baf06a68333a196b3d8d241480a774733dcf8b"
+  name = "go.uber.org/zap"
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore",
+  ]
+  pruneopts = "UT"
+  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
+  version = "v1.9.1"
+
+[[projects]]
   branch = "master"
   digest = "1:d9f9f45d3383b93ce1c7e744b3ede6974917ae4d100e1a7abfc2906e5e5e2e28"
   name = "golang.org/x/net"
@@ -118,6 +149,7 @@
     "github.com/docker/docker/api/types/filters",
     "github.com/docker/docker/client",
     "github.com/jessevdk/go-flags",
+    "go.uber.org/zap",
     "golang.org/x/sync/errgroup",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  name = "go.uber.org/zap"
+  version = "1.9.1"

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -136,9 +136,7 @@ func (d *Discovery) Run(ctx context.Context, sugar *zap.SugaredLogger) {
 		case _ = <-ticker.C:
 			_, err := d.RunDiscovery(ctx)
 			if err != nil {
-				sugar.Errorw("Regularly runDiscovery failed",
-					"reason", err,
-				)
+				sugar.Errorw("Regularly runDiscovery failed", zap.Error(err))
 			}
 		}
 	}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	client "github.com/docker/docker/client"
+	"go.uber.org/zap"
 )
 
 const (
@@ -126,7 +126,7 @@ func (d *Discovery) Get(ctx context.Context, privatePort uint16) ([]BackendConta
 }
 
 // Run refresh token regularly
-func (d *Discovery) Run(ctx context.Context) {
+func (d *Discovery) Run(ctx context.Context, sugar *zap.SugaredLogger) {
 	ticker := time.NewTicker(refreshInterval * time.Second)
 	defer ticker.Stop()
 	for {
@@ -136,7 +136,9 @@ func (d *Discovery) Run(ctx context.Context) {
 		case _ = <-ticker.C:
 			_, err := d.RunDiscovery(ctx)
 			if err != nil {
-				log.Printf("Regularly runDiscovery failed:%v", err)
+				sugar.Errorw("Regularly runDiscovery failed",
+					"reason", err,
+				)
 			}
 		}
 	}

--- a/motarei.go
+++ b/motarei.go
@@ -55,16 +55,12 @@ Compiler: %s %s
 
 	d, err := discovery.NewDiscovery(ctx, opts.DockerLabel)
 	if err != nil {
-		sugar.Fatalw("failed initialize discovery",
-			"reason", err,
-		)
+		sugar.Fatalw("failed initialize discovery", zap.Error(err))
 	}
 	privatePorts := d.GetPrivatePorts()
 	_, err = d.RunDiscovery(ctx)
 	if err != nil {
-		sugar.Fatalw("failed first discovery",
-			"reason", err,
-		)
+		sugar.Fatalw("failed first discovery", zap.Error(err))
 	}
 	go d.Run(ctx, sugar)
 
@@ -81,8 +77,6 @@ Compiler: %s %s
 	}
 	if err := eg.Wait(); err != nil {
 		defer cancel()
-		sugar.Fatalw("failed to start proxy",
-			"reason", err,
-		)
+		sugar.Fatalw("failed to start proxy", zap.Error(err))
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -74,17 +74,13 @@ func (p *Proxy) Start(ctx context.Context, sugar *zap.SugaredLogger) error {
 func (p *Proxy) handleConn(ctx context.Context, sugar *zap.SugaredLogger, c net.Conn) error {
 	backends, err := p.d.Get(ctx, p.port)
 	if err != nil {
-		sugar.Errorw("Failed to get backends",
-			"reason", err,
-		)
+		sugar.Errorw("Failed to get backends", zap.Error(err))
 		c.Close()
 		return err
 	}
 
 	if len(backends) == 0 {
-		sugar.Errorw("Failed to get backends port",
-			"reason", "no backend was found",
-		)
+		sugar.Error("Failed to get backends port")
 		c.Close()
 		return fmt.Errorf("Failed to get backends port")
 	}
@@ -95,16 +91,12 @@ func (p *Proxy) handleConn(ctx context.Context, sugar *zap.SugaredLogger, c net.
 		if err == nil {
 			break
 		} else {
-			sugar.Errorw("Failed to connect backend",
-				"reason", err,
-			)
+			sugar.Errorw("Failed to connect backend", zap.Error(err))
 		}
 	}
 
 	if err != nil {
-		sugar.Errorw("Giveup to connect backends",
-			"reason", err,
-		)
+		sugar.Errorw("Giveup to connect backends", zap.Error(err))
 		c.Close()
 		return err
 	}
@@ -118,9 +110,7 @@ func (p *Proxy) handleConn(ctx context.Context, sugar *zap.SugaredLogger, c net.
 		_, err := io.Copy(s, c)
 		if err != nil {
 			if !goClose {
-				sugar.Errorw("Copy from client",
-					"reason", err,
-				)
+				sugar.Errorw("Copy from client", zap.Error(err))
 				return
 			}
 		}
@@ -133,9 +123,7 @@ func (p *Proxy) handleConn(ctx context.Context, sugar *zap.SugaredLogger, c net.
 		_, err := io.Copy(c, s)
 		if err != nil {
 			if !goClose {
-				sugar.Errorw("Copy from upstream",
-					"reason", err,
-				)
+				sugar.Errorw("Copy from upstream", zap.Error(err))
 				return
 			}
 		}


### PR DESCRIPTION
In this PR, I just replace standard `log` package to `go.uber.org/zap`.

Currently I use global logger defined in zap package because we need to change all function signatures to accept logger as function parameter.

But this approach is not recommended.
https://github.com/uber-go/zap/blob/master/FAQ.md#why-include-package-global-loggers
> Avoid them where possible

~~I want to discuss which approach we will take.~~
we decided not to use global logger