### PR TITLE
delete unreachable code

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -81,11 +81,6 @@ func (p *Proxy) handleConn(ctx context.Context, c net.Conn) error {
 		return err
 	}
 
-	if len(backends) == 0 {
-		p.logger.Error("Failed to get backends port")
-		c.Close()
-		return fmt.Errorf("Failed to get backends port")
-	}
 	var s net.Conn
 	for _, backend := range backends {
 		// log.Printf("Proxy %s:%d => 127.0.0.1:%d (%s)", p.listen, p.port, backend.PublicPort, c.RemoteAddr())


### PR DESCRIPTION
refer: https://github.com/kazeburo/motarei/issues/5

simply delete unreachable if block.

if there is other solution that is more preferable than this, i can fix this.
(e.g. return empty slice instead of error when backend container is not found in `*Discovery.Get`, and so on)
Or just close this PR if we do not need to take any action.