### PR TITLE
introduced proxy-connect-ip

### DIFF
--- a/motarei.go
+++ b/motarei.go
@@ -21,6 +21,7 @@ type cmdOpts struct {
 	BindIP              string        `long:"bind" default:"0.0.0.0" description:"IP address to bind"`
 	DockerLabel         string        `long:"label" short:"l" description:"label to filter container. eg app=nginx" required:"true"`
 	ProxyConnectTimeout time.Duration `long:"proxy-connect-timeout" default:"60s" description:"timeout of connection to upstream"`
+	ProxyConnectIP      string        `long:"proxy-connect-ip" default:"127.0.0.1" description:"destination ip address to connect to upstream"`
 	Version             bool          `short:"v" long:"version" description:"Show version"`
 }
 
@@ -69,7 +70,7 @@ Compiler: %s %s
 	for _, port := range privatePorts {
 		port := port
 		eg.Go(func() error {
-			p := proxy.NewProxy(opts.BindIP, port, opts.ProxyConnectTimeout, d, logger)
+			p := proxy.NewProxy(opts.BindIP, opts.ProxyConnectIP, port, opts.ProxyConnectTimeout, d, logger)
 			return p.Start(ctx)
 		})
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,6 +18,7 @@ const (
 // Proxy proxy struct
 type Proxy struct {
 	listen  string
+	ip      string
 	port    uint16
 	timeout time.Duration
 	d       *discovery.Discovery
@@ -26,9 +27,10 @@ type Proxy struct {
 }
 
 // NewProxy create new proxy
-func NewProxy(listen string, port uint16, timeout time.Duration, d *discovery.Discovery, logger *zap.Logger) *Proxy {
+func NewProxy(listen, ip string, port uint16, timeout time.Duration, d *discovery.Discovery, logger *zap.Logger) *Proxy {
 	return &Proxy{
 		listen:  listen,
+		ip:      ip,
 		port:    port,
 		timeout: timeout,
 		d:       d,
@@ -84,7 +86,7 @@ func (p *Proxy) handleConn(ctx context.Context, c net.Conn) error {
 	var s net.Conn
 	for _, backend := range backends {
 		// log.Printf("Proxy %s:%d => 127.0.0.1:%d (%s)", p.listen, p.port, backend.PublicPort, c.RemoteAddr())
-		s, err = net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", backend.PublicPort), p.timeout)
+		s, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", p.ip, backend.PublicPort), p.timeout)
 		if err == nil {
 			break
 		} else {


### PR DESCRIPTION
proxy host interface ip instead of 127.0.0.1 for skipping userland docker-proxy.

https://blog.yuuk.io/entry/docker-performance-on-web-application

> benchmarker はデフォルトでは 127.0.0.1:80 へ接続するため、benchmarker - Nginx 間での接続に、ホストの 0.0.0.0:80 で LISTEN してる docker-proxy が使われてしまうという事態になっています。 benchmarker のオプションで --host <host eth0 ipaddr> としてやると、iptables でルーティングされるようになるため、スコアはDocker化していない状態とほぼ同じになりました。
